### PR TITLE
improve remove expression

### DIFF
--- a/comentar_trad_ed.lua
+++ b/comentar_trad_ed.lua
@@ -136,7 +136,7 @@ function change_tag(subs,index,config)
 					--Okay, senpai, it's a promise then.
 				end
 			else		
-				linha.text = linha.text:gsub(" ?{EN: .+}", "")
+				linha.text = linha.text:gsub(" ?{EN: [^}]*}", "")
 				--Remove tudo criado
 			end
 	subs[index] = linha

--- a/comentar_trad_ed_english.lua
+++ b/comentar_trad_ed_english.lua
@@ -119,7 +119,7 @@ function change_tag(subs,index,config)
 					-- Okay, senpai, it's a promise then.
 				end
 			else		
-				dialogue.text = dialogue.text:gsub(" ?{en: .+}", "")
+				dialogue.text = dialogue.text:gsub(" ?{en: [^}]*}", "")
 				-- Remove everything written
 			end
 	subs[index] = dialogue


### PR DESCRIPTION
Changed gsub expression for "Remove translation comments"
It fixes a bug that would delete everything after {EN: ...}, even though there could be text after that